### PR TITLE
Revamp profile README and add social badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ![Profile Views](https://komarev.com/ghpvc/?username=shunta-furukawa&color=blue)
 
+[![Website](https://img.shields.io/badge/Website-shunta--furukawa.info-FE1E75?style=flat&logo=safari&logoColor=white)](https://shunta-furukawa.info)
+[![Zenn](https://img.shields.io/badge/Zenn-shunta__furukawa-3EA8FF?style=flat&logo=zenn&logoColor=white)](https://zenn.dev/shunta_furukawa)
+[![X](https://img.shields.io/badge/X-@shunta__furukawa-000000?style=flat&logo=x&logoColor=white)](https://x.com/shunta_furukawa)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-shunta--furukawa-0A66C2?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/shunta-furukawa)
+[![Facebook](https://img.shields.io/badge/Facebook-shunta.furukawa-1877F2?style=flat&logo=facebook&logoColor=white)](https://www.facebook.com/shunta.furukawa)
+
 </div>
 
 ## About Me

--- a/README.md
+++ b/README.md
@@ -1,30 +1,34 @@
-[![Typing SVG](https://readme-typing-svg.herokuapp.com?font=Roboto+Mono&weight=900&size=30&repeat=false&pause=1000&color=FE1E75&width=435&lines=%F0%9F%91%8B+Hi%2C+This+is+Shunta+Furukawa.)](https://git.io/typing-svg)
+<div align="center">
+
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Roboto+Mono&weight=900&size=30&repeat=false&pause=1000&color=FE1E75&width=435&lines=%F0%9F%91%8B+Hi%2C+This+is+Shunta+Furukawa.)](https://git.io/typing-svg)
 
 ![Profile Views](https://komarev.com/ghpvc/?username=shunta-furukawa&color=blue)
 
+</div>
+
 ## About Me
 
-Hi, I’m Shunta. I’m a backend engineer and problem solver with a deep interest in building systems that are reliable, scalable, and designed to simplify complex workflows. My journey in tech has been driven by a passion for understanding not just how things work, but why they matter.
+Hi, I'm Shunta — a backend engineer who enjoys building systems that are reliable, scalable, and designed to simplify complex workflows. I gravitate toward the *why* behind a system as much as the *how*.
 
 ## Skills & Tools
 
 [![My Skills](https://skillicons.dev/icons?i=go,ruby,js,python,rails,kubernetes,docker,gcp,aws,postgres,mysql,mongodb,git,github)](https://skillicons.dev)
 
-Languages: Go, Ruby, JavaScript, Python
-Frameworks: Ruby on Rails
-Infrastructure: Kubernetes, Docker, GCP, AWS
-Databases: PostgreSQL, MySQL, MongoDB
-Version Control: Git, GitHub
+- **Languages** — Go, Ruby, JavaScript, Python
+- **Frameworks** — Ruby on Rails
+- **Infrastructure** — Kubernetes, Docker, GCP, AWS
+- **Databases** — PostgreSQL, MySQL, MongoDB
+
+## GitHub Stats
+
+<div align="center">
 
 ![Shunta's GitHub stats](https://github-readme-stats.vercel.app/api?username=shunta-furukawa&show_icons=true&theme=radical)
+![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=shunta-furukawa&layout=compact&theme=radical)
+![GitHub Streak](https://streak-stats.demolab.com?user=shunta-furukawa&theme=radical)
 
-### About My Contribution Graph
-#### 🔒 Note
+</div>
 
-I primarily use a different GitHub account for work, which is why the contribution graph for this account might look a bit sparse. Please bear with me!
-If you're curious about my work contributions, feel free to check out my work account here:
-[🌐 My Work Account](https://github.com/abema-shunta)
-
-Please note: Since this is a private work account, you might not be able to see much activity unless you have the appropriate access.
-
----
+> 📊 **About the contribution graph** — I primarily use a different GitHub account for work, so activity here looks sparse. This account hosts side projects and experiments.
+>
+> For my work footprint, see [🌐 @abema-shunta](https://github.com/abema-shunta). Most repos there are private, so visibility depends on your access.


### PR DESCRIPTION
## Summary
- Swap the dead readme-typing-svg Heroku URL for the demolab.com mirror, and flatten the broken heading nesting under Skills
- Tighten About Me prose, reformat Skills as a bullet list, add Top Languages and Streak Stats cards under a unified GitHub Stats section, consolidate the work-account note into one blockquote
- Surface the SNS/website links published on shunta-furukawa.info (Website, Zenn, X, LinkedIn, Facebook) as shields.io badges in the header

## Test plan
- [ ] Confirm the typing SVG renders (demolab.com)
- [ ] Confirm Top Languages and Streak Stats cards load
- [ ] Click each badge to verify it lands on the correct profile