### PR TITLE
Refine profile content and visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Typing SVG](https://readme-typing-svg.demolab.com?font=Roboto+Mono&weight=900&size=30&repeat=false&pause=1000&color=FE1E75&width=435&lines=%F0%9F%91%8B+Hi%2C+This+is+Shunta+Furukawa.)](https://git.io/typing-svg)
 
-![Profile Views](https://komarev.com/ghpvc/?username=shunta-furukawa&color=blue)
+![Profile Views](https://komarev.com/ghpvc/?username=shunta-furukawa&color=FE1E75&style=flat)
 
 [![Website](https://img.shields.io/badge/Website-shunta--furukawa.info-FE1E75?style=flat&logo=safari&logoColor=white)](https://shunta-furukawa.info)
 [![Zenn](https://img.shields.io/badge/Zenn-shunta__furukawa-3EA8FF?style=flat&logo=zenn&logoColor=white)](https://zenn.dev/shunta_furukawa)
@@ -14,24 +14,35 @@
 
 ## About Me
 
-Hi, I'm Shunta — a backend engineer who enjoys building systems that are reliable, scalable, and designed to simplify complex workflows. I gravitate toward the *why* behind a system as much as the *how*.
+Hi, I'm Shunta. Backend engineering is my core, but I work across the stack — from Go and Kubernetes on the server to frontend interfaces and visual design. I'm drawn to problems where engineering, product, and design overlap, and I care more about the *why* of a system than the *how*.
 
 ## Skills & Tools
 
-[![My Skills](https://skillicons.dev/icons?i=go,ruby,js,python,rails,kubernetes,docker,gcp,aws,postgres,mysql,mongodb,git,github)](https://skillicons.dev)
+[![My Skills](https://skillicons.dev/icons?i=go,ruby,js,python,html,css,rails,kubernetes,docker,terraform,gcp,aws,postgres,mysql,mongodb,git,github)](https://skillicons.dev)
 
-- **Languages** — Go, Ruby, JavaScript, Python
-- **Frameworks** — Ruby on Rails
-- **Infrastructure** — Kubernetes, Docker, GCP, AWS
-- **Databases** — PostgreSQL, MySQL, MongoDB
+- **Backend** — Go, Ruby (Rails), Python
+- **Frontend** — JavaScript, HTML, CSS
+- **Infrastructure** — Kubernetes, Docker, Terraform, GCP, AWS
+- **Data** — PostgreSQL, MySQL, MongoDB
+- **Design** — UI/UX & graphic design
 
 ## GitHub Stats
 
 <div align="center">
 
-![Shunta's GitHub stats](https://github-readme-stats.vercel.app/api?username=shunta-furukawa&show_icons=true&theme=radical)
-![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=shunta-furukawa&layout=compact&theme=radical)
-![GitHub Streak](https://streak-stats.demolab.com?user=shunta-furukawa&theme=radical)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=shunta-furukawa&show_icons=true&theme=radical">
+  <img alt="Shunta's GitHub stats" src="https://github-readme-stats.vercel.app/api?username=shunta-furukawa&show_icons=true&theme=default" width="48%">
+</picture>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=shunta-furukawa&layout=compact&theme=radical">
+  <img alt="Top Languages" src="https://github-readme-stats.vercel.app/api/top-langs/?username=shunta-furukawa&layout=compact&theme=default" width="48%">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=shunta-furukawa&theme=radical">
+  <img alt="GitHub Streak" src="https://streak-stats.demolab.com?user=shunta-furukawa&theme=default" width="97%">
+</picture>
 
 </div>
 


### PR DESCRIPTION
## Summary
- Expand **About Me** to reflect the full-stack + design framing on shunta-furukawa.info, instead of the generic "backend engineer" line
- Reorganize **Skills** into Backend / Frontend / Infrastructure / Data / Design buckets and add HTML, CSS, Terraform to the skill icons
- Match Profile Views badge color to the pink brand accent (`FE1E75`)
- Wrap stats cards in `<picture>` so they switch theme based on `prefers-color-scheme` (radical for dark, default for light)
- Lay main stats and top-languages **side by side** (48% each), streak full-width, for cleaner alignment

## Test plan
- [ ] View the profile in both light and dark mode and confirm the stat cards switch themes
- [ ] Confirm side-by-side cards don't wrap on standard viewports
- [ ] Verify all skill icons render