### PR TITLE
Remove trophy section (upstream service down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,6 @@
 
 </div>
 
-### Trophies / トロフィー
-
-<div align="center">
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github-profile-trophy.vercel.app/?username=shunta-furukawa&theme=radical&column=6&margin-w=15&margin-h=15&no-frame=true">
-  <img alt="Trophies" src="https://github-profile-trophy.vercel.app/?username=shunta-furukawa&theme=flat&column=6&margin-w=15&margin-h=15&no-frame=true">
-</picture>
-
-</div>
-
 ### Activity / アクティビティ
 
 <div align="center">


### PR DESCRIPTION
## Summary
- `github-profile-trophy.vercel.app` is currently returning **HTTP 503** (confirmed via WebFetch) and has been unreliable for a while
- Remove the Trophies section from the README rather than ship a broken image
- Activity graph and other modules are unaffected

## Test plan
- [ ] Confirm profile page no longer shows a broken trophy image
- [ ] Confirm the activity graph still renders